### PR TITLE
Fixed ATOM parsing

### DIFF
--- a/app/models/feed.rb
+++ b/app/models/feed.rb
@@ -22,6 +22,7 @@ class Feed < ApplicationRecord
 	def update_feed_items
 		begin
 			xml = HTTParty.get(self.uri).body
+			Feedjira::Parser::Atom.preprocess_xml = true
 			rss = Feedjira.parse(xml)
 		rescue => e
 			puts "Error updating feed items for feed: #{self.uri}. #{e.message}"


### PR DESCRIPTION
Prevent it from stripping out HTML content when the content type is xhtml per https://github.com/feedjira/feedjira/issues/214